### PR TITLE
Fix handling of empty exclude opt in test scripts

### DIFF
--- a/script/test
+++ b/script/test
@@ -22,9 +22,14 @@ if [ $? -eq 1 ]; then
 fi
 
 echo "\n=== Running cljs tests"
-clojure -R:test:test-cljs \
-        -m cljs-test-runner.main -d src -r "$regex" \
-        -e "$exclude"
+if [ -z "$exclude" ]; then
+    clojure -R:test:test-cljs \
+            -m cljs-test-runner.main -d src -r "$regex"
+else
+    clojure -R:test:test-cljs \
+            -m cljs-test-runner.main -d src -r "$regex" \
+            -e "$exclude"
+fi
 
 if [ $? -eq 1 ]; then
     exit_code=1

--- a/script/test-one
+++ b/script/test-one
@@ -22,11 +22,18 @@ if [ $? -eq 1 ]; then
 fi
 
 echo "\n=== Running cljs test $1"
-clojure -R:test:test-cljs \
-        -m cljs-test-runner.main -d src \
-        -n "$ns" \
-        -n "$1" \
-        -e "$exclude"
+if [ -z "$exclude" ]; then
+    clojure -R:test:test-cljs \
+            -m cljs-test-runner.main -d src \
+            -n "$ns" \
+            -n "$1"
+else
+    clojure -R:test:test-cljs \
+            -m cljs-test-runner.main -d src \
+            -n "$ns" \
+            -n "$1" \
+            -e "$exclude"
+fi
 
 if [ $? -eq 1 ]; then
     exit_code=1


### PR DESCRIPTION
The cljs test runner gets unhappy with a set that gets interpolated as `#{:}` in its generated code.

There may be a nicer way to do this; just figured I should let you know there was an issue whilst running the CLJS tests locally.